### PR TITLE
Switch from forked Deno to upstream Deno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.0.3 Jun 30, 2022
+
+- switch to upstream Deno
+- upgrade to deno.land/x/polkadot@0.0.2
+
 ## 0.0.2 Jun 30, 2022
 
 - add tini.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN ln -sf /bin/hub /bin/agent
 ADD subsh-deno /bin/
 
 COPY *.ts .
+COPY package.json .
 
 ENV DENO_DIR=/cache
 

--- a/cache.ts
+++ b/cache.ts
@@ -1,5 +1,18 @@
-// import { ApiPromise, WsProvider } from "@polkadot/api";
 import { ApiPromise, WsProvider } from 'https://deno.land/x/polkadot@0.0.1/api/mod.ts';
+
+import fs from 'fs';
+
+async function initApi(){
+  const PROVIDER = Deno.env.get("PROVIDER") ?? "wss://rpc.polkadot.io";
+  const provider = new WsProvider( PROVIDER );
+  return await ApiPromise.create({ provider });
+}
+
+console.log("api is initializing. Please hold on...");
+
+const api = await initApi();
+
+const _stat = fs.lstatSync('.')
 
 console.log("cache complete");
 Deno.exit();

--- a/ci-release.ts
+++ b/ci-release.ts
@@ -22,7 +22,7 @@ const RE_PKG = /deno\.land\/x\/subshell(@\d*\.\d*\.\d*(-\d*)?)?\//g;
 // regex for matching `deno.land/x/polkadot[@<version>]/
 const RE_PKG_POLKADOT = /deno\.land\/x\/polkadot(@\d*\.\d*\.\d*(-\d*)?)?\//g;
 
-const POLKADOT_VERSION = "0.0.1"
+const POLKADOT_VERSION = "0.0.2"
 
 // execute a command
 async function exec(...cmd: string[]): Promise<void> {

--- a/init.ts
+++ b/init.ts
@@ -52,7 +52,7 @@ function progInfo() {
   const info = {
     // "⚙️ v8 version ": Deno.version.v8,
     // "🇹 TypeScript version ": Deno.version.typescript,
-    "🦕 Deno": "1.23.0",
+    "🦕 Deno": Deno.version.deno,
     "📗 Wiki": "https://wiki.subshell.xyz",
     "🙋 Issues": "https://github.com/btwiuse/subshell/issues",
     // "⛓️ RPC Pprvider": PROVIDER,

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,3 @@
 #!/usr/bin/env -S deno run -A
 
-const status = await Deno.run({ cmd: ["subshell", "repl", "--unstable", "--compat", "--eval-file=https://deno.land/x/subshell@0.0.2/init.ts"] }).status();
+const status = await Deno.run({ cmd: ["deno", "repl", "--unstable", "--compat", "--eval-file=https://deno.land/x/subshell@0.0.2/init.ts"] }).status();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/subsh-deno
+++ b/subsh-deno
@@ -5,18 +5,15 @@ if [[ -z "$RUNNING_IN_DOCKER" ]]; then
   cd $(dirname $(realpath $0))
 fi
 
-deno(){
-  subshell "$@"
-# /bin/deno "$@"
-}
+DENO=deno
 
 if [[ "$1" == cache ]]; then
   until
-    deno run --unstable cache.ts --compat --cache-only
+    $DENO run --unstable --compat -A cache.ts 
   do
     sleep 1
   done
-  deno run --unstable cache.ts --compat
+  $DENO run --unstable --compat -A cache.ts
 else
-  deno repl --unstable --eval-file=https://deno.land/x/subshell/init.ts --compat
+  $DENO repl --unstable --compat --eval-file=https://deno.land/x/subshell@0.0.2/init.ts
 fi


### PR DESCRIPTION
In the next release, deno.land/x/polkadot will come with a fix that allows tab completion to work in upstream Deno, making the fork unecessary.

Closes #1 .